### PR TITLE
Move sql logic into utility classes

### DIFF
--- a/ml_experiment/DefinitionPart.py
+++ b/ml_experiment/DefinitionPart.py
@@ -1,6 +1,4 @@
 import os
-import sqlite3
-
 from itertools import product
 
 from typing import Dict, Iterable, Set
@@ -33,7 +31,7 @@ class DefinitionPart:
 
         save_path = self.get_results_path()
         db_path = os.path.join(save_path, 'metadata.db')
-        con = _init_db(db_path)
+        con = sqlu.init_db(db_path)
         cur = con.cursor()
         tables = sqlu.get_tables(cur)
 
@@ -93,11 +91,6 @@ class DefinitionPart:
         con.commit()
         con.close()
 
-
-def _init_db(db_path: str):
-    os.makedirs(os.path.dirname(db_path), exist_ok=True)
-    con = sqlite3.connect(db_path)
-    return con
 
 def generate_configurations(properties: Dict[str, Set[ValueType]]):
     for configuration in product(*properties.values()):

--- a/ml_experiment/DefinitionPart.py
+++ b/ml_experiment/DefinitionPart.py
@@ -5,6 +5,7 @@ from typing import Dict, Iterable, Set
 from collections import defaultdict
 
 import ml_experiment._utils.sqlite as sqlu
+from ml_experiment.metadata.MetadataTableRegistry import MetadataTableRegistry
 
 ValueType = int | float | str | bool
 
@@ -33,60 +34,41 @@ class DefinitionPart:
         db_path = os.path.join(save_path, 'metadata.db')
         con = sqlu.init_db(db_path)
         cur = con.cursor()
-        tables = sqlu.get_tables(cur)
 
-        # get table version
-        latest_version = -1
-        for t in {t for t in tables if t.startswith(self.name)}:
-            version = int(t.replace(self.name + '-v', ''))
-            if version > latest_version:
-                latest_version = version
+        table_registry = MetadataTableRegistry()
 
-        if latest_version == -1:
-            for i, configuration in enumerate(configurations):
-                configuration['id'] = i
-        else:
+        # tag configurations with the appropriate configuration id
+        # grabbing from prior tables where possible, or generating a unique id for new configs
+        next_config_id = table_registry.get_max_configuration_id(cur, self.name) + 1
+        for configuration in configurations:
+            existing_id = table_registry.get_configuration_id(cur, self.name, configuration)
 
-            # find next id for new configurations
-            all_ids = []
-            for i in range(latest_version + 1):
-                _table_name = self.name + f'-v{i}'
-                cur.execute(f"SELECT DISTINCT id FROM '{_table_name}'")
-                all_ids.extend([x[0] for x in cur.fetchall()])
-            next_id = max(all_ids) + 1
+            if existing_id is not None:
+                configuration['id'] = existing_id
 
-            # assign ids to new configurations / find ids for existing configurations
-            for configuration in configurations:
-                _id = None
+            else:
+                configuration['id'] = next_config_id
+                next_config_id += 1
 
-                for i in range(latest_version, -1, -1):
-                    table_name = self.name + f'-v{i}'
 
-                    # check if properties match the table schema
-                    cur.execute(f"PRAGMA table_info('{table_name}')")
-                    columns = set([x[1] for x in cur.fetchall()])
+        # determine whether we should build a new table
+        # and what version to call that table
+        latest_table = table_registry.get_latest_version(cur, self.name)
 
-                    if not set(configuration.keys()) == columns - {'id'} :
-                        continue
+        next_table_version = 0
+        skip_build = False
+        if latest_table is not None:
+            next_table_version = latest_table.version + 1
 
-                    # check if configuration exists
-                    cur.execute(f"SELECT id FROM '{table_name}' WHERE {' AND '.join([f'{k}=?' for k in configuration.keys()])}", list(configuration.values()))
-                    _id = cur.fetchone()
-                    if _id:
-                        break
+            # check if the current latest table contains exactly the same configs
+            expected_config_ids = set(c['id'] for c in configurations)
+            current_config_ids = latest_table.get_configuration_ids(cur)
 
-                if _id:
-                    configuration['id'] = _id[0]
-                else:
-                    configuration['id'] = next_id
-                    next_id += 1
+            skip_build = expected_config_ids == current_config_ids
 
-        table_name = self.name + f'-v{latest_version + 1}'
-
-        sqlu.create_table(cur, table_name, list(self._properties.keys()) + ['id INTEGER PRIMARY KEY'])
-        conf_string = ', '.join(['?'] * (len(self._properties) + 1))
-        column_names = ', '.join(list(self._properties.keys()) + ['id'])
-        cur.executemany(f"INSERT INTO '{table_name}' ({column_names}) VALUES ({conf_string})", [list(c.values()) for c in configurations])
+        if not skip_build:
+            table = table_registry.create_new_table(cur, self.name, next_table_version, self._properties.keys())
+            table.add_configurations(cur, configurations)
 
         con.commit()
         con.close()

--- a/ml_experiment/_utils/sqlite.py
+++ b/ml_experiment/_utils/sqlite.py
@@ -1,10 +1,26 @@
-from sqlite3 import Cursor
+import os
+import sqlite3
+
 from typing import Set, List
 
-def get_tables(cur: Cursor) -> Set[str]:
-    res = cur.execute("SELECT name FROM sqlite_master")
-    return set(r[0] for r in res.fetchall())
+# --------------
+# -- Creation --
+# --------------
 
-def create_table(cur: Cursor, table_name: str, columns: List[str]):
+def create_table(cur: sqlite3.Cursor, table_name: str, columns: List[str]):
     columns_str = ', '.join(columns)
     cur.execute(f"CREATE TABLE '{table_name}' ({columns_str})")
+
+def init_db(db_path: str):
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    con = sqlite3.connect(db_path)
+    return con
+
+
+# -------------
+# -- Getters --
+# -------------
+
+def get_tables(cur: sqlite3.Cursor) -> Set[str]:
+    res = cur.execute("SELECT name FROM sqlite_master")
+    return set(r[0] for r in res.fetchall())

--- a/ml_experiment/metadata/MetadataTable.py
+++ b/ml_experiment/metadata/MetadataTable.py
@@ -1,0 +1,83 @@
+import sqlite3
+from typing import Dict, Iterable, Set
+
+# TODO: find some root-level place to store these types
+ValueType = int | float | str | bool
+
+class MetadataTable:
+    def __init__(self, part_name: str, version: int):
+        self.part_name = part_name
+        self.version = version
+
+        # cached results
+        self._cols: Set[str] | None = None
+        self._configuration_ids: Set[int] | None = None
+
+
+    def get_table_name(self):
+        return f'{self.part_name}-v{self.version}'
+
+
+    def get_columns(self, cur: sqlite3.Cursor) -> Set[str]:
+        if self._cols is not None:
+            return self._cols
+
+        res = (
+            cur.execute("PRAGMA table_info('?')", self.get_table_name())
+            .fetchall()
+        )
+        self._cols = set(x[1] for x in res)
+        return self._cols
+
+
+    def get_configuration_columns(self, cur: sqlite3.Cursor):
+        cols = self.get_columns(cur)
+        return cols - {'id'}
+
+
+    def get_configuration_ids(self, cur: sqlite3.Cursor) -> Set[int]:
+        if self._configuration_ids is not None:
+            return self._configuration_ids
+
+        res = (
+            cur.execute("SELECT DISTINCT id FROM '?'", self.get_table_name())
+            .fetchall()
+        )
+        self._configuration_ids = set(x[0] for x in res)
+        return self._configuration_ids
+
+
+    def get_configuration_id(self, cur: sqlite3.Cursor, configuration: Dict[str, ValueType]) -> int | None:
+        col_names = self.get_configuration_columns(cur)
+
+        # if this table does not have the same columns
+        # then we already know it does not have the correct id
+        # shortcutting here prevents an SQL error due to mismatching columns
+        if col_names != set(configuration.keys()):
+            return None
+
+        # otherwise, query the table for the id
+        table_name = self.get_table_name()
+        where = ' AND '.join(f'"{k}"={configuration[k]}' for k in col_names)
+
+        res = (
+            cur.execute(f"SELECT id FROM '{table_name}' WHERE {where}")
+            .fetchone()
+        )
+
+        if res is None:
+            return None
+
+        return res[0]
+
+
+    def add_configurations(self, cur: sqlite3.Cursor, configurations: Iterable[Dict[str, ValueType]]):
+        # get an ordered list of cols
+        cols = list(self.get_columns(cur))
+
+        table_name = self.get_table_name()
+        conf_str = ', '.join(['?'] * len(cols))
+        col_names = ', '.join(cols)
+        conf_values = [list(c.values()) for c in configurations]
+
+        cur.executemany(f"INSERT INTO '{table_name}' ({col_names}) VALUES ({conf_str})", conf_values)

--- a/ml_experiment/metadata/MetadataTable.py
+++ b/ml_experiment/metadata/MetadataTable.py
@@ -23,7 +23,7 @@ class MetadataTable:
             return self._cols
 
         res = (
-            cur.execute("PRAGMA table_info('?')", self.get_table_name())
+            cur.execute(f"PRAGMA table_info('{self.get_table_name()}')")
             .fetchall()
         )
         self._cols = set(x[1] for x in res)
@@ -40,7 +40,7 @@ class MetadataTable:
             return self._configuration_ids
 
         res = (
-            cur.execute("SELECT DISTINCT id FROM '?'", self.get_table_name())
+            cur.execute(f"SELECT DISTINCT id FROM '{self.get_table_name()}'")
             .fetchall()
         )
         self._configuration_ids = set(x[0] for x in res)

--- a/ml_experiment/metadata/MetadataTable.py
+++ b/ml_experiment/metadata/MetadataTable.py
@@ -78,6 +78,6 @@ class MetadataTable:
         table_name = self.get_table_name()
         conf_str = ', '.join(['?'] * len(cols))
         col_names = ', '.join(cols)
-        conf_values = [list(c.values()) for c in configurations]
+        conf_values = [[c[k] for k in cols] for c in configurations]
 
         cur.executemany(f"INSERT INTO '{table_name}' ({col_names}) VALUES ({conf_str})", conf_values)

--- a/ml_experiment/metadata/MetadataTableRegistry.py
+++ b/ml_experiment/metadata/MetadataTableRegistry.py
@@ -1,0 +1,111 @@
+import sqlite3
+import ml_experiment._utils.sqlite as sqlu
+
+from typing import Dict, Iterable
+from ml_experiment.metadata.MetadataTable import MetadataTable, ValueType
+
+
+class MetadataTableRegistry:
+    def __init__(self):
+        # cached results
+        self._latest_versions: Dict[str, int] = {}
+        self._tables: Dict[str, MetadataTable] = {}
+
+
+    def get_table(self, cur: sqlite3.Cursor, part_name: str, version: int) -> MetadataTable | None:
+        table_name = f'{part_name}-v{version}'
+
+        # check cache
+        if table_name in self._tables:
+            return self._tables[table_name]
+
+        # ensure table exists
+        tables = sqlu.get_tables(cur)
+        if table_name not in tables:
+            return None
+
+        # construct table object
+        self._tables[table_name] = table = MetadataTable(part_name, version)
+        return table
+
+
+    def get_tables(self, cur: sqlite3.Cursor, part_name: str):
+        table_names = sqlu.get_tables(cur)
+
+        for t in table_names:
+            if not t.startswith(part_name):
+                continue
+
+            version = int(t.replace(f'{part_name}-v', ''))
+            table = self.get_table(cur, part_name, version)
+
+            if table is not None:
+                yield table
+
+
+    def get_latest_version(self, cur: sqlite3.Cursor, part_name: str) -> MetadataTable | None:
+        if part_name in self._latest_versions:
+            version = self._latest_versions[part_name]
+            return self.get_table(cur, part_name, version)
+
+
+        tables = list(self.get_tables(cur, part_name))
+        if len(tables) == 0:
+            return None
+
+        latest = max(t.version for t in tables)
+        self._latest_versions[part_name] = latest
+        return self.get_table(cur, part_name, latest)
+
+
+    def get_max_configuration_id(self, cur: sqlite3.Cursor, part_name: str) -> int:
+        all_ids = set[int]()
+
+        tables = self.get_tables(cur, part_name)
+        for t in tables:
+            all_ids |= t.get_configuration_ids(cur)
+
+        # define the no configurations case (e.g. this is table v0)
+        # as having a max id of -1
+        if len(all_ids) == 0:
+            return -1
+
+        return max(all_ids)
+
+
+    def get_configuration_id(self, cur: sqlite3.Cursor, part_name: str, configuration: Dict[str, ValueType]) -> int | None:
+        latest = self.get_latest_version(cur, part_name)
+
+        if latest is None:
+            return None
+
+        # walk backwards starting from the latest version
+        # if any table contains an id, then stop
+        for i in range(latest.version + 1):
+            table = self.get_table(cur, part_name, version=latest.version - i)
+
+            if table is None:
+                continue
+
+            conf_id = table.get_configuration_id(cur, configuration)
+            if conf_id is not None:
+                return conf_id
+
+        return None
+
+
+    def create_new_table(self, cur: sqlite3.Cursor, part_name: str, version: int, config_params: Iterable[str]) -> MetadataTable:
+        table_name = f'{part_name}-v{version}'
+        sqlu.create_table(cur, table_name, list(config_params) + ['id INTEGER PRIMARY KEY'])
+
+        # since we just created this table, it better be there!
+        table = self.get_table(cur, part_name, version)
+        assert table is not None
+
+        # invalidate the version cache, since we should now have a new version
+        # assert that versions are strictly monotonically increasing
+        if part_name in self._latest_versions:
+            assert self._latest_versions[part_name] < version
+            self._latest_versions[part_name] = version
+
+        return table


### PR DESCRIPTION
This PR builds on #2 and so should be merged afterwards. For now, contains duplicated commits (I will deal with these + merge conflicts that comes from stacked PRs).

Novel to this PR is a large refactor of the `commit` code, moving all of the SQL logic out of the primary class. This way, the `commit` function is responsible only for the "business logic", while the utility classes are responsible for dealing with the implementation details of SQL.

We should sit together to go through this PR and to do some testing. I intend to shift my focus to our automated test infrastructure after this.