### PR TITLE
Utility to run tests locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ results/
 experiments/
 .pytest_cache/
 .venv/
+.coverage

--- a/local_tests.sh
+++ b/local_tests.sh
@@ -4,7 +4,8 @@ source .temp_venv_89232740428678165126/bin/activate
 pip install uv
 uv pip compile --extra=dev pyproject.toml -o requirements.txt
 uv pip sync requirements.txt
+uv pip install '.[dev]'
 
-pytest --cov=ml_experiment
+pytest tests/ --cov=ml_experiment
 
 rm -rf .temp_venv_89232740428678165126

--- a/local_tests.sh
+++ b/local_tests.sh
@@ -1,0 +1,10 @@
+# don't use this venv please, it's just for testing purposes
+python -m venv .temp_venv_89232740428678165126
+source .temp_venv_89232740428678165126/bin/activate
+pip install uv
+uv pip compile --extra=dev pyproject.toml -o requirements.txt
+uv pip sync requirements.txt
+
+pytest --cov=ml_experiment
+
+rm -rf .temp_venv_89232740428678165126


### PR DESCRIPTION
Adds `./local_tests.sh`, which can be called to run `pytest` in exactly the same way as in the github ci workflow. It is not elegant, but it fixes an issue I had where calling `pytest` resulted in passing tests even though github ci tests failed. 

We could instead use tox etc to standardize testing. 