### PR TITLE
Add experiment name to all the database readers and writers

### DIFF
--- a/ml_experiment/ExperimentDefinition.py
+++ b/ml_experiment/ExperimentDefinition.py
@@ -1,45 +1,45 @@
-from typing import Any
 import os
 import sqlite3
+from typing import Any
 
 from ml_experiment.metadata.MetadataTable import MetadataTable
-from ml_experiment._utils.path import get_results_path
+
 
 class ExperimentDefinition:
-    def __init__(self, part_name: str, version: int, base: str | None = None):
+    def __init__(
+        self, exp_name: str, part_name: str, version: int, base: str | None = None
+    ):
+        self.exp_name = exp_name
         self.part_name = part_name
         self.version = version
         self.base_path = base or os.getcwd()
-        self.get_results_path = get_results_path
 
         self.table = MetadataTable(self.part_name, self.version)
 
+    def get_results_path(self) -> str:
+        return os.path.join(self.base_path, "results", self.exp_name)
+
     def get_config(self, config_id: int) -> dict[str, Any]:
-        save_path = self.get_results_path(self.base_path)
-        db_path = os.path.join(save_path, 'metadata.db')
+        save_path = self.get_results_path()
+        db_path = os.path.join(save_path, "metadata.db")
 
         with sqlite3.connect(db_path) as con:
             cur = con.cursor()
             return self.table.get_configuration(cur, config_id)
 
-
-
-    def get_configs(self, config_ids: list[int], product_seeds: list[int] | None = None) -> list[dict[str, Any]]:
-        save_path = self.get_results_path(self.base_path)
-        db_path = os.path.join(save_path, 'metadata.db')
+    def get_configs(
+        self, config_ids: list[int], product_seeds: list[int] | None = None
+    ) -> list[dict[str, Any]]:
+        save_path = self.get_results_path()
+        db_path = os.path.join(save_path, "metadata.db")
 
         with sqlite3.connect(db_path) as con:
             cur = con.cursor()
             _c = [
-                self.table.get_configuration(cur, config_id)
-                for config_id in config_ids
+                self.table.get_configuration(cur, config_id) for config_id in config_ids
             ]
 
             if product_seeds is not None:
-                return [
-                    {**c, 'seed': seed}
-                    for c in _c
-                    for seed in product_seeds
-                ]
+                return [{**c, "seed": seed} for c in _c for seed in product_seeds]
             else:
                 return _c

--- a/tests/test_DefinitionPart.py
+++ b/tests/test_DefinitionPart.py
@@ -2,8 +2,8 @@ from ml_experiment.DefinitionPart import DefinitionPart
 
 
 def test_add_sweepable_property():
-    builder = DefinitionPart('qrc')
-    builder.add_sweepable_property('key_1', [1, 2, 3])
+    builder = DefinitionPart("temp", "qrc")
+    builder.add_sweepable_property("key_1", [1, 2, 3])
 
     for i in range(1, 4):
-        builder.add_property('key_2', i)
+        builder.add_property("key_2", i)

--- a/tests/test_ExperimentDefinition.py
+++ b/tests/test_ExperimentDefinition.py
@@ -1,62 +1,40 @@
-import os
-
 from ml_experiment.DefinitionPart import DefinitionPart
 from ml_experiment.ExperimentDefinition import ExperimentDefinition
 
 
 def test_ExperimentDefinition(tmp_path):
-
     # build dummy experiment
-    exp_name = 'dummy_experiment'
-    part_name = 'qrc'
+    exp_name = "dummy_experiment"
+    part_name = "qrc"
 
-    part = stubbed_DefinitionPart(exp_name, part_name, base = str(tmp_path))
-    part.add_sweepable_property('alpha', (2**-i for i in range(3, 8)))
-    part.add_sweepable_property('beta', [0.5, 1.0, 2.0])
+    part = DefinitionPart(exp_name, part_name, base=str(tmp_path))
+    part.add_sweepable_property("alpha", (2**-i for i in range(3, 8)))
+    part.add_sweepable_property("beta", [0.5, 1.0, 2.0])
     part.commit()
-
 
     # load experiment definition
     version = 0
     config_ids = [1, 2, 3]
     seeds = [1, 2]
 
-    exp = stubbed_ExperimentDefinition(exp_name, part_name, version, base = str(tmp_path))
+    exp = ExperimentDefinition(exp_name, part_name, version, base=str(tmp_path))
 
     config = exp.get_config(0)
-    assert config == {'alpha': 0.125, 'beta': 0.5, 'id': 0}
+    assert config == {"alpha": 0.125, "beta": 0.5, "id": 0}
 
     configs = exp.get_configs(config_ids)
     assert configs == [
-        {'alpha': 0.125, 'beta': 1.0, 'id': 1},
-        {'alpha': 0.125, 'beta': 2.0, 'id': 2},
-        {'alpha': 0.0625, 'beta': 0.5, 'id': 3},
+        {"alpha": 0.125, "beta": 1.0, "id": 1},
+        {"alpha": 0.125, "beta": 2.0, "id": 2},
+        {"alpha": 0.0625, "beta": 0.5, "id": 3},
     ]
-
 
     configs_and_seeds = exp.get_configs(config_ids, product_seeds=seeds)
     assert configs_and_seeds == [
-        {'alpha': 0.125, 'beta': 1.0, 'id': 1, 'seed': 1},
-        {'alpha': 0.125, 'beta': 1.0, 'id': 1, 'seed': 2},
-        {'alpha': 0.125, 'beta': 2.0, 'id': 2, 'seed': 1},
-        {'alpha': 0.125, 'beta': 2.0, 'id': 2, 'seed': 2},
-        {'alpha': 0.0625, 'beta': 0.5, 'id': 3, 'seed': 1},
-        {'alpha': 0.0625, 'beta': 0.5, 'id': 3, 'seed': 2},
+        {"alpha": 0.125, "beta": 1.0, "id": 1, "seed": 1},
+        {"alpha": 0.125, "beta": 1.0, "id": 1, "seed": 2},
+        {"alpha": 0.125, "beta": 2.0, "id": 2, "seed": 1},
+        {"alpha": 0.125, "beta": 2.0, "id": 2, "seed": 2},
+        {"alpha": 0.0625, "beta": 0.5, "id": 3, "seed": 1},
+        {"alpha": 0.0625, "beta": 0.5, "id": 3, "seed": 2},
     ]
-
-
-class stubbed_DefinitionPart(DefinitionPart):
-    def __init__(self, exp_name: str, name: str, base: str | None = None):
-        self.exp_name = exp_name
-        super().__init__(name, base)
-
-    def get_results_path(self, base_path) -> str:
-        return os.path.join(base_path, 'results', self.exp_name)
-
-class stubbed_ExperimentDefinition(ExperimentDefinition):
-    def __init__(self, exp_name: str, part_name: str, version: int, base: str | None = None):
-        self.exp_name = exp_name
-        super().__init__(part_name, version, base)
-
-    def get_results_path(self, base_path) -> str:
-        return os.path.join(base_path, 'results', self.exp_name)


### PR DESCRIPTION
Not sure if we want to go this route, but it fixes #18. 

Adds `self.exp_name` to DefinitionPart, ExperimentDefinition, and Scheduler. Scheduler also passes `--results_path` to the `entry.py` main experiments file. 