### PR TITLE
feat: add basic tagging cli tool

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -10,16 +10,16 @@ jobs:
     steps:
       # setup the repository
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           cache: 'pip'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
       - run: |
-          python -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip compile --extra=dev pyproject.toml -o requirements.txt
-          uv pip sync requirements.txt
+          uv venv
+          uv sync
 
       - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -11,8 +11,6 @@ jobs:
       # setup the repository
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with:
-          cache: 'pip'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,17 +20,16 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
       - run: |
-          python -m venv .venv
-          source .venv/bin/activate
-          pip install uv
-          uv pip compile --extra=dev pyproject.toml -o requirements.txt
-          uv pip sync requirements.txt
-          uv pip install '.[dev]'
+          uv venv
+          uv sync
 
       - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
 
-      - run: pytest tests/ --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml --cov=ml_experiment --cov-report=html:coverage/cov-${{ matrix.os }}-${{ matrix.python-version }}.html
+      - run: uv run pytest tests/ --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml --cov=ml_experiment --cov-report=html:coverage/cov-${{ matrix.os }}-${{ matrix.python-version }}.html
 
       - name: Upload pytest test results
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ results/
 experiments/
 .pytest_cache/
 .venv/
+uv.lock
+*.egg-info

--- a/ml_experiment/Scheduler.py
+++ b/ml_experiment/Scheduler.py
@@ -95,14 +95,14 @@ class Scheduler:
 
     def _run_local(self, c: LocalRunConfig) -> None:
         pool = Pool(c.tasks_in_parallel)
-        res = pool.imap(partial(self._run_single, c), self.all_runs)
+        res = pool.imap_unordered(partial(self._run_single, c), self.all_runs)
 
         for i, _ in enumerate(res):
             sys.stderr.write(f'\r{i+1}/{len(self.all_runs)}')
         sys.stderr.write('\n')
 
     def _run_single(self, c: LocalRunConfig, r: RunSpec) -> None:
-        subprocess.run([c.python_path, '-m', self.entry, '--part', r.part_name, '--config-id', str(r.config_id), '--seed', str(r.seed), '--version', str(r.version), '--results-path', self.results_path, '--silent'])
+        subprocess.run([c.python_path, self.entry, '--part', r.part_name, '--config-id', str(r.config_id), '--seed', str(r.seed), '--version', str(r.version), '--results-path', self.results_path, '--silent'])
 
 
     def _resolve_version(
@@ -132,5 +132,3 @@ class Scheduler:
     def _sanity_check(self):
         res_path = os.path.join(self.base_path, 'results', self.exp_name, 'metadata.db')
         assert os.path.exists(res_path), f'{res_path}: {self.exp_name} does not exist'
-
-

--- a/ml_experiment/_utils/maybe.py
+++ b/ml_experiment/_utils/maybe.py
@@ -25,6 +25,13 @@ class Maybe(Generic[T]):
         return f(self._v)
 
 
+    def otherwise(self, f: Callable[[], T | None]) -> Maybe[T]:
+        if self._v is None:
+            return Maybe(f())
+
+        return self
+
+
     def flat_otherwise(self, f: Callable[[], Maybe[T]]) -> Maybe[T]:
         if self._v is None:
             return f()

--- a/ml_experiment/_utils/path.py
+++ b/ml_experiment/_utils/path.py
@@ -4,9 +4,10 @@ def get_experiment_name():
     import __main__
     return __main__.__file__.split(os.path.sep)[-2]
 
-def get_results_path(base_path: str) -> str:
+def get_results_path(base_path: str, experiment: str | None = None) -> str:
+    exp = experiment or get_experiment_name()
     return os.path.join(
         base_path,
         'results',
-        get_experiment_name(),
+        exp,
     )

--- a/ml_experiment/_utils/sqlite.py
+++ b/ml_experiment/_utils/sqlite.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import sqlite3
 
 from typing import Set, List
@@ -11,7 +12,7 @@ def create_table(cur: sqlite3.Cursor, table_name: str, columns: List[str]):
     columns_str = ', '.join(columns)
     cur.execute(f"CREATE TABLE '{table_name}' ({columns_str})")
 
-def init_db(db_path: str):
+def init_db(db_path: str | Path):
     os.makedirs(os.path.dirname(db_path), exist_ok=True)
     con = sqlite3.connect(db_path)
     return con

--- a/ml_experiment/cli.py
+++ b/ml_experiment/cli.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from sqlite3 import Cursor
+import click
+
+from ml_experiment._utils.maybe import Maybe
+from ml_experiment.expdata.tag_table import TagTable
+from ml_experiment.metadata.metadata_table_registry import MetadataTableRegistry
+
+import ml_experiment._utils.sqlite as sqlu
+
+
+@click.group()
+def main():
+    ...
+
+@main.group('tag')
+def tag():
+    ...
+
+@tag.command('add')
+@click.argument('tag')
+@click.argument('experiment')
+@click.argument('part_name')
+@click.argument('version', type=int, required=False)
+def add_tag(tag: str, experiment: str, part_name: str, version: int | None):
+    path = Path('results') / experiment / 'metadata.db'
+
+    if not path.exists():
+        raise Exception(f'Experiment {experiment} does not exist')
+
+    cur = sqlu.init_db(path).cursor()
+    v = Maybe(version) \
+        .flat_otherwise(lambda: _get_latest_version(cur, part_name)) \
+        .expect('Did not find a version for given part name')
+
+    tag_table = TagTable(cur)
+    tag_table.add_tag(tag, part_name, v)
+
+
+def _get_latest_version(cur: Cursor, part_name: str):
+    registry = MetadataTableRegistry()
+    table = registry.get_latest_version(cur, part_name)
+    return Maybe(table).map(lambda t: t.version)

--- a/ml_experiment/definition_part.py
+++ b/ml_experiment/definition_part.py
@@ -11,10 +11,10 @@ from ml_experiment.metadata.metadata_table_registry import MetadataTableRegistry
 ValueType = int | float | str | bool
 
 class DefinitionPart:
-    def __init__(self, name: str, base: str | None = None):
+    def __init__(self, name: str, experiment: str | None = None, base: str | None = None):
         self.name = name
         self.base_path = base or os.getcwd()
-        self.get_results_path = get_results_path
+        self.results_path = get_results_path(self.base_path, experiment)
 
         self._properties: Dict[str, Set[ValueType]] = defaultdict(set)
         self._prior_values: Dict[str, ValueType] = {}
@@ -44,8 +44,7 @@ class DefinitionPart:
     def commit(self):
         configurations = list(generate_configurations(self._properties))
 
-        save_path = self.get_results_path(self.base_path)
-        db_path = os.path.join(save_path, 'metadata.db')
+        db_path = os.path.join(self.results_path, 'metadata.db')
         con = sqlu.init_db(db_path)
         cur = con.cursor()
 

--- a/ml_experiment/expdata/tag_table.py
+++ b/ml_experiment/expdata/tag_table.py
@@ -1,0 +1,51 @@
+from sqlite3 import Cursor
+
+import ml_experiment._utils.sqlite as sqlu
+
+class TagTable:
+    def __init__(self, cur: Cursor):
+        self._cur = cur
+
+        tables = sqlu.get_tables(self._cur)
+        if '__tags__' not in tables:
+            self._make_table()
+
+    def _make_table(self):
+        cur = self._cur
+        sqlu.create_table(
+            cur,
+            '__tags__',
+            ['tag', 'part', 'version'],
+        )
+
+    def _insert(self, tag: str, part: str, version: int):
+        self._cur.execute(
+            "INSERT INTO '__tags__' (tag, part, version) VALUES (?, ?, ?)",
+            (tag, part, version),
+        )
+        self._cur.connection.commit()
+        return self._cur
+
+    def _update_or_insert(self, tag: str, part: str, version: int):
+        self._cur.execute(
+            "INSERT OR REPLACE INTO '__tags__'"
+                "(tag, part, version) VALUES (:tag, :part, :version)",
+            {'tag': tag, 'part': part, 'version': version},
+        )
+        self._cur.connection.commit()
+        return self._cur
+
+    def add_tag(self, tag: str, part_name: str, version: int):
+        self._update_or_insert(tag, part_name, version)
+
+    def get_table(self, tag: str) -> tuple[str, int] | None:
+        cur = self._cur
+        table = cur.execute(
+            "SELECT part, version FROM '__tags__' WHERE tag=?",
+            (tag,),
+        ).fetchone()
+
+        if table is None:
+            return table
+
+        return table[0][0], int(table[0][1])

--- a/ml_experiment/experiment_definition.py
+++ b/ml_experiment/experiment_definition.py
@@ -6,16 +6,16 @@ from ml_experiment.metadata.metadata_table import MetadataTable
 from ml_experiment._utils.path import get_results_path
 
 class ExperimentDefinition:
-    def __init__(self, part_name: str, version: int, base: str | None = None):
+    def __init__(self, part_name: str, version: int, experiment: str | None = None, base: str | None = None):
         self.part_name = part_name
         self.version = version
         self.base_path = base or os.getcwd()
-        self.get_results_path = get_results_path
+        self.results_path = get_results_path(self.base_path, experiment)
 
         self.table = MetadataTable(self.part_name, self.version)
 
     def get_config(self, config_id: int) -> dict[str, Any]:
-        save_path = self.get_results_path(self.base_path)
+        save_path = self.results_path
         db_path = os.path.join(save_path, 'metadata.db')
 
         with sqlite3.connect(db_path) as con:
@@ -25,7 +25,7 @@ class ExperimentDefinition:
 
 
     def get_configs(self, config_ids: list[int], product_seeds: list[int] | None = None) -> list[dict[str, Any]]:
-        save_path = self.get_results_path(self.base_path)
+        save_path = self.results_path
         db_path = os.path.join(save_path, 'metadata.db')
 
         with sqlite3.connect(db_path) as con:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,10 @@ authors = [
     {name = "Parham Panahi", email = "parham1@ualberta.ca"},
     {name = "Andy Patterson", email = "ap3@ualberta.ca"},
 ]
-dependencies = []
+dependencies = [
+    "click>=8.1.8",
+    "rich~=13.9",
+]
 requires-python = ">=3.11,<3.13"
 readme = "README.md"
 license = {text = "MIT"}
@@ -38,13 +41,20 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 
-[project.optional-dependencies]
+[project.scripts]
+exp = "ml_experiment.cli:main"
+
+[dependency-groups]
 dev = [
-    "pip",
-    "ruff",
-    "pytest",
-    "pytest-cov",
-    "pyright",
-    "commitizen",
-    "pre-commit",
+    "commitizen>=4.2.1",
+    "pip>=25.0",
+    "pre-commit>=4.1.0",
+    "pyright>=1.1.393",
+    "pytest>=8.3.4",
+    "pytest-cov>=6.0.0",
+    "ruff>=0.9.5",
 ]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ select = ['F', 'E', 'W', 'B']
 ignore = ['E501', 'E701', 'B023']
 
 [tool.pyright]
-include = ['ml_experiment']
+include = ['ml_experiment', 'tests']
 venvPath = '.'
 venv = '.venv'
 typeCheckingMode = 'standard'

--- a/tests/acceptance/my_experiment.py
+++ b/tests/acceptance/my_experiment.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+from pathlib import Path
 import random
 
 from ml_experiment.experiment_definition import ExperimentDefinition
@@ -43,9 +44,8 @@ def main():
     random.seed(cmdline.seed)
 
     # extract configs from the database
-    exp = ExperimentDefinition("softmaxAC", cmdline.version)
-    # TODO: don't overwrite this
-    exp.get_results_path = lambda *args, **kwargs: cmdline.results_path # overwrite results path
+    base = Path(cmdline.results_path).parents[1]
+    exp = ExperimentDefinition("softmaxAC", cmdline.version, experiment='acceptance', base=str(base))
     config = exp.get_config(cmdline.config_id)
 
     # make our dummy agent

--- a/tests/acceptance/my_experiment.py
+++ b/tests/acceptance/my_experiment.py
@@ -10,6 +10,7 @@ parser.add_argument("--config-id", type=int, required=True)
 parser.add_argument("--seed", type=int, required=True)
 parser.add_argument("--version", type=int, required=True)
 parser.add_argument("--results-path", type=str, required=True)
+parser.add_argument('--silent', action='store_true', default=False, required=False)
 
 class SoftmaxAC:
     def __init__(

--- a/tests/acceptance/test_softmaxAC_mc.py
+++ b/tests/acceptance/test_softmaxAC_mc.py
@@ -12,9 +12,9 @@ def base_path(request):
     import __main__
     __main__.__file__ = request.path.__fspath__()
 
-def write_database(tmp_path, alphas: list[float], taus: list[float]):
+def write_database(tmp_path, experiment: str, alphas: list[float], taus: list[float]):
     # make table writer
-    softmaxAC = DefinitionPart("softmaxAC", base=str(tmp_path))
+    softmaxAC = DefinitionPart("softmaxAC", experiment, base=str(tmp_path))
 
     # add properties to sweep
     softmaxAC.add_sweepable_property("alpha", alphas)
@@ -64,7 +64,7 @@ def test_read_database(tmp_path, base_path):
     )
 
     # write experiment definition to table
-    write_database(tmp_path, alphas, taus)
+    write_database(tmp_path, 'acceptance', alphas, taus)
 
     # make Experiment object (versions start at 0)
     softmaxAC_mc = ExperimentDefinition(
@@ -107,13 +107,13 @@ def test_run_tasks(tmp_path):
     expected_configs = {i : config for i, config in enumerate(partial_configs)}
 
     # set experiment file name
-    experiment_file_name = f"tests/{exp_name}/my_experiment.py"
+    experiment_file_name = os.getcwd() + f"/tests/{exp_name}/my_experiment.py"
 
     # set results path
-    results_path = os.path.join(tmp_path, "results", f"{exp_name}")
+    results_path = os.path.join(tmp_path, "results", exp_name)
 
     # write experiment definition to table
-    db = write_database(tmp_path, alphas, taus)
+    db = write_database(tmp_path, exp_name, alphas, taus)
 
     assert db.name == "softmaxAC"
     assert os.path.exists(os.path.join(results_path, "metadata.db"))
@@ -162,7 +162,3 @@ def test_run_tasks(tmp_path):
         with open(output_path, "r") as f:
             output = f.read()
             assert output.strip() == expected_output
-
-
-
-

--- a/tests/metadata/test_MetadataTableRegistry.py
+++ b/tests/metadata/test_MetadataTableRegistry.py
@@ -19,7 +19,7 @@ def test_get_parts(tmp_path):
 
     # find database file
     meta = MetadataTableRegistry()
-    res_path = os.path.join(df.get_results_path(df.base_path), "metadata.db")
+    res_path = os.path.join(df.results_path, "metadata.db")
 
     ## initial test to get part name
     # get parts

--- a/tests/test_ExperimentDefinition.py
+++ b/tests/test_ExperimentDefinition.py
@@ -1,5 +1,3 @@
-import os
-
 from ml_experiment.definition_part import DefinitionPart
 from ml_experiment.experiment_definition import ExperimentDefinition
 
@@ -10,7 +8,7 @@ def test_ExperimentDefinition(tmp_path):
     exp_name = 'dummy_experiment'
     part_name = 'qrc'
 
-    part = stubbed_DefinitionPart(exp_name, part_name, base = str(tmp_path))
+    part = DefinitionPart(part_name, experiment=exp_name, base = str(tmp_path))
     part.add_sweepable_property('alpha', (2**-i for i in range(3, 8)))
     part.add_sweepable_property('beta', [0.5, 1.0, 2.0])
     part.commit()
@@ -21,7 +19,7 @@ def test_ExperimentDefinition(tmp_path):
     config_ids = [1, 2, 3]
     seeds = [1, 2]
 
-    exp = stubbed_ExperimentDefinition(exp_name, part_name, version, base = str(tmp_path))
+    exp = ExperimentDefinition(part_name, version, experiment=exp_name, base = str(tmp_path))
 
     config = exp.get_config(0)
     assert config == {'alpha': 0.125, 'beta': 0.5, 'id': 0}
@@ -43,20 +41,3 @@ def test_ExperimentDefinition(tmp_path):
         {'alpha': 0.0625, 'beta': 0.5, 'id': 3, 'seed': 1},
         {'alpha': 0.0625, 'beta': 0.5, 'id': 3, 'seed': 2},
     ]
-
-
-class stubbed_DefinitionPart(DefinitionPart):
-    def __init__(self, exp_name: str, name: str, base: str | None = None):
-        self.exp_name = exp_name
-        super().__init__(name, base)
-
-    def get_results_path(self, base_path) -> str:
-        return os.path.join(base_path, 'results', self.exp_name)
-
-class stubbed_ExperimentDefinition(ExperimentDefinition):
-    def __init__(self, exp_name: str, part_name: str, version: int, base: str | None = None):
-        self.exp_name = exp_name
-        super().__init__(part_name, version, base)
-
-    def get_results_path(self, base_path) -> str:
-        return os.path.join(base_path, 'results', self.exp_name)


### PR DESCRIPTION
This PR adds a simple CLI tool for tagging a given experiment, part name, and version tuple (if version is not specified, then default to latest version).
```bash
exp tag add my_tag experiment_name part_name
```

It's a bit verbose and we should workshop the syntax a bit (maybe use `--flag`s instead of positional args?).

While not the highest priority CLI tool, this was a useful demonstrative tool for getting the CLI framework set up.